### PR TITLE
Fix random sampling to be without replacement

### DIFF
--- a/ch04/negative_sampling_layer.rb
+++ b/ch04/negative_sampling_layer.rb
@@ -66,9 +66,7 @@ class UnigramSampler
       p[target_idx] = 0
       p /= p.sum
       negative_sample[i, true] =
-        random_weighted_sample_no_replacement(@vocab_size,
-                                              @sample_size,
-                                              p) { |x| x }
+        random_choice_without_replacement(@vocab_size, size: @sample_size, p: p)
     end
 
     negative_sample

--- a/ch04/negative_sampling_layer.rb
+++ b/ch04/negative_sampling_layer.rb
@@ -1,5 +1,6 @@
 require 'numo/narray'
 require_relative '../common/layers'
+require_relative '../common/random_sampling'
 
 class EmbeddingDot
   attr_accessor :params, :grads
@@ -65,7 +66,9 @@ class UnigramSampler
       p[target_idx] = 0
       p /= p.sum
       negative_sample[i, true] =
-        random_choice(@vocab_size, size: @sample_size, p: p)
+        random_weighted_sample_no_replacement(@vocab_size,
+                                              @sample_size,
+                                              p) { |x| x }
     end
 
     negative_sample

--- a/ch04/negative_sampling_layer.rb
+++ b/ch04/negative_sampling_layer.rb
@@ -65,8 +65,9 @@ class UnigramSampler
       target_idx = target[i]
       p[target_idx] = 0
       p /= p.sum
-      negative_sample[i, true] =
-        random_choice_without_replacement(@vocab_size, size: @sample_size, p: p)
+      negative_sample[i, true] = RandomSampling.random_choice(
+        @vocab_size, size: @sample_size, p: p, replacement: false
+      )
     end
 
     negative_sample

--- a/common/functions.rb
+++ b/common/functions.rb
@@ -123,28 +123,3 @@ def paired_access_idxs(x, idxs1, idxs2)
 
   full_idxs
 end
-
-# Choose `size` (default: 1) numbers of elements from `a` with the given
-# probability (defaults to equal probability).
-# `a` can either be an array or Integer in which case it will be treated as
-# `(0...a).to_a`.
-#
-# Implementation is based on the Weighted Random Sampling by Efraimidis and Spirakis
-# (https://link.springer.com/referenceworkentry/10.1007%2F978-0-387-30162-4_478).
-#
-# @param a [Array or Integer] Array to choose from.
-# @param size [Integer] Number of elements to pick. Default is 1.
-# @param p [Array<Numeric>] Array of probabilities.
-# @return [Array] Array of items chosen.
-def random_choice(a, size: 1, p: nil)
-  array = a.class == Integer ? (0...a).to_a : a
-
-  if p
-    raise 'The number of probabilities do not match the size of the array.' \
-      if array.length != p.length
-    val_to_weight = array.zip(p).to_h
-    val_to_weight.max_by(size) { |_, weight| rand ** (1.0 / weight) }.map(&:first)
-  else
-    array.sample(size)
-  end
-end

--- a/common/random_sampling.rb
+++ b/common/random_sampling.rb
@@ -46,13 +46,23 @@ def rws_heap_pop(h)
   v
 end
 
-def random_weighted_sample_no_replacement(a, n, p)
+# Choose `size` (default: 1) numbers of elements from `a` with the given
+# probability without replacement.
+# `a` can either be an array or Integer in which case it will be treated as
+# `(0...a).to_a`.
+#
+# Implementation is based on the Weighted Random Sampling from this SO
+# (https://stackoverflow.com/a/2149533/4037).
+#
+# @param a [Array or Integer] Array to choose from.
+# @param size [Integer] Number of elements to pick. Default is 1.
+# @param p [Array<Numeric>] Array of probabilities.
+# @return [Array] Array of items chosen.
+def random_choice_without_replacement(a, size: 1, p:)
   array = a.class == Integer ? (0...a).to_a : a
   items = array.zip(p)
 
   heap = rws_heap(items)
 
-  n.times do
-    yield rws_heap_pop(heap)
-  end
+  size.times.map { rws_heap_pop(heap) }
 end

--- a/common/random_sampling.rb
+++ b/common/random_sampling.rb
@@ -46,8 +46,12 @@ def rws_heap_pop(h)
   v
 end
 
-def random_weighted_sample_no_replacement(items, n)
+def random_weighted_sample_no_replacement(a, n, p)
+  array = a.class == Integer ? (0...a).to_a : a
+  items = array.zip(p)
+
   heap = rws_heap(items)
+
   n.times do
     yield rws_heap_pop(heap)
   end

--- a/common/random_sampling.rb
+++ b/common/random_sampling.rb
@@ -1,68 +1,92 @@
 # frozen_string_literal: true
 
 # Implementation of Weighted Random Sampling.
-# Proudly stolen from:
-#   https://stackoverflow.com/a/2149533/4037
-
-Node = Struct.new(:w, :v, :tw)
-Rand = Random.new
-
-def rws_heap(items)
-  h = [nil]
-  items.each do |w, v|
-    h.append(Node.new(w, v, w))
-  end
-
-  (h.length - 1).downto(2).each do |i|
-    h[i >> 1].tw += h[i].tw
-  end
-
-  h
-end
-
-def rws_heap_pop(h)
-  gas = h[1].tw * Rand.rand
-
-  i = 1
-
-  while gas >= h[i].w
-    gas -= h[i].w
-    i <<= 1
-    if gas >= h[i].tw
-      gas -= h[i].tw
-      i += 1
+class RandomSampling
+  # Choose `size` (default: 1) numbers of elements from `a` with the given
+  # probability.
+  # `a` can either be an array or Integer in which case it will be treated as
+  # `(0...a).to_a`.
+  #
+  # @param a [Array or Integer] Array to choose from.
+  # @param size [Integer] Number of elements to pick. Default is 1.
+  # @param p [Array<Numeric>] Array of probabilities.
+  # @param replacement [Boolean] `true` if with replacement. Defaults to true.
+  # @return [Array] Array of items chosen.
+  def self.random_choice(a, size: 1, p:, replacement: true)
+    if replacement
+      random_choice_with_replacement(a, size: size, p: p)
+    else
+      random_choice_without_replacement(a, size: size, p: p)
     end
   end
 
-  w = h[i].w
-  v = h[i].v
+  # Implementation is based on the Weighted Random Sampling by Efraimidis and
+  # Spirakis (https://link.springer.com/referenceworkentry/10.1007%2F978-0-387-30162-4_478).
+  def self.random_choice_with_replacement(a, size: 1, p: nil)
+    array = a.class == Integer ? (0...a).to_a : a
 
-  h[i].w = 0
-  while i.positive?
-    h[i].tw -= w
-    i >>= 1
+    if p
+      raise 'The number of probabilities do not match the size of the array.' \
+        if array.length != p.length
+
+      val_to_weight = array.zip(p).to_h
+      val_to_weight.max_by(size) { |_, weight| rand**(1.0 / weight) }
+                   .map(&:first)
+    else
+      array.sample(size)
+    end
   end
 
-  v
-end
+  # Implementation is based on the Weighted Random Sampling from this SO
+  # (https://stackoverflow.com/a/2149533).
+  def self.random_choice_without_replacement(a, size: 1, p:)
+    array = a.class == Integer ? (0...a).to_a : a
+    items = array.zip(p)
 
-# Choose `size` (default: 1) numbers of elements from `a` with the given
-# probability without replacement.
-# `a` can either be an array or Integer in which case it will be treated as
-# `(0...a).to_a`.
-#
-# Implementation is based on the Weighted Random Sampling from this SO
-# (https://stackoverflow.com/a/2149533/4037).
-#
-# @param a [Array or Integer] Array to choose from.
-# @param size [Integer] Number of elements to pick. Default is 1.
-# @param p [Array<Numeric>] Array of probabilities.
-# @return [Array] Array of items chosen.
-def random_choice_without_replacement(a, size: 1, p:)
-  array = a.class == Integer ? (0...a).to_a : a
-  items = array.zip(p)
+    heap = rws_heap(items)
 
-  heap = rws_heap(items)
+    size.times.map { rws_heap_pop(heap) }
+  end
 
-  size.times.map { rws_heap_pop(heap) }
+  Node = Struct.new(:w, :v, :tw)
+  Rand = Random.new
+
+  def self.rws_heap(items)
+    h = [nil]
+    items.each do |w, v|
+      h.append(Node.new(w, v, w))
+    end
+
+    (h.length - 1).downto(2).each do |i|
+      h[i >> 1].tw += h[i].tw
+    end
+
+    h
+  end
+
+  def self.rws_heap_pop(h)
+    gas = h[1].tw * Rand.rand
+
+    i = 1
+
+    while gas >= h[i].w
+      gas -= h[i].w
+      i <<= 1
+      if gas >= h[i].tw
+        gas -= h[i].tw
+        i += 1
+      end
+    end
+
+    w = h[i].w
+    v = h[i].v
+
+    h[i].w = 0
+    while i.positive?
+      h[i].tw -= w
+      i >>= 1
+    end
+
+    v
+  end
 end

--- a/common/random_sampling.rb
+++ b/common/random_sampling.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Implementation of Weighted Random Sampling.
+# Proudly stolen from:
+#   https://stackoverflow.com/a/2149533/4037
+
+Node = Struct.new(:w, :v, :tw)
+Rand = Random.new
+
+def rws_heap(items)
+  h = [nil]
+  items.each do |w, v|
+    h.append(Node.new(w, v, w))
+  end
+
+  (h.length - 1).downto(2).each do |i|
+    h[i >> 1].tw += h[i].tw
+  end
+
+  h
+end
+
+def rws_heap_pop(h)
+  gas = h[1].tw * Rand.rand
+
+  i = 1
+
+  while gas >= h[i].w
+    gas -= h[i].w
+    i <<= 1
+    if gas >= h[i].tw
+      gas -= h[i].tw
+      i += 1
+    end
+  end
+
+  w = h[i].w
+  v = h[i].v
+
+  h[i].w = 0
+  while i.positive?
+    h[i].tw -= w
+    i >>= 1
+  end
+
+  v
+end
+
+def random_weighted_sample_no_replacement(items, n)
+  heap = rws_heap(items)
+  n.times do
+    yield rws_heap_pop(heap)
+  end
+end


### PR DESCRIPTION
The initial weighted random sampling was using an implementation with replacement whereas the intention was to use one *without* replacement.